### PR TITLE
Make BigNumber.toString(16) produce better hex

### DIFF
--- a/src/bignum/bignum.js
+++ b/src/bignum/bignum.js
@@ -94,10 +94,8 @@ function BigNumber_toString ( radix ) {
             str += h;
         }
 
-        str = str.replace( /^0+/, '' );
-
         if ( !str.length )
-            str = '0';
+            str = '00';
     }
     else {
         throw new IllegalArgumentError("bad radix");


### PR DESCRIPTION
BigNumber.toString(16) should leave the stripping of extra zero's as something the user can choose to do. I suggest removing the stripping functionality all together, but providing it as a optional boolean parameter would work as well.
