### PR TITLE
AES ECB should be only used on real random AES size blocks.

### DIFF
--- a/asmcrypto.js.d.ts
+++ b/asmcrypto.js.d.ts
@@ -50,12 +50,20 @@ declare interface RSA_PSS_Verify {
 }
 
 declare class AES_ECB_Encrypt extends AES {
+  constructor(key: Uint8Array, heap?: Uint8Array);
   reset: AES_reset<AES_ECB_Encrypt>;
   process: AES_Encrypt_process<AES_ECB_Encrypt>;
   finish: AES_Encrypt_finish<AES_ECB_Encrypt>;
 }
 
+declare class AES_ECB extends AES {
+  constructor(key: Uint8Array, heap?: Uint8Array, asm?: Uint8Array);
+  encrypt: AES_Encrypt_finish<AES_ECB>;
+  decrypt: AES_Decrypt_finish<AES_ECB>;
+}
+
 declare class AES_ECB_Decrypt extends AES {
+  constructor(key: Uint8Array, heap?: Uint8Array);
   reset: AES_reset<AES_ECB_Decrypt>;
   process: AES_Encrypt_process<AES_ECB_Decrypt>;
   finish: AES_Decrypt_finish<AES_ECB_Decrypt>;
@@ -137,8 +145,8 @@ declare module 'asmcrypto.js/asmcrypto.all.js' {
   }
 
   export const AES_ECB: {
-    encrypt: (data: Uint8Array, key: Uint8Array, padding?: boolean) => Uint8Array;
-    decrypt: (data: Uint8Array, key: Uint8Array, padding?: boolean) => Uint8Array;
+    encrypt: (data: Uint8Array, key: Uint8Array) => Uint8Array;
+    decrypt: (data: Uint8Array, key: Uint8Array) => Uint8Array;
     Encrypt: typeof AES_ECB_Encrypt;
     Decrypt: typeof AES_ECB_Decrypt;
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asmcrypto.js",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Asm.js implementation of WebCrypto API",
   "homepage": "https://github.com/vibornoff/asmcrypto.js",
   "main": "asmcrypto.js",

--- a/src/aes/ecb/ecb.js
+++ b/src/aes/ecb/ecb.js
@@ -6,12 +6,11 @@ import {AES} from '../aes';
 export class AES_ECB extends AES {
   /**
    * @param {Uint8Array} key
-   * @param {boolean} [padding=true]
    * @param {Uint8Array} [heap]
    * @param {Uint8Array} [asm]
    */
-  constructor(key, padding = true, heap, asm) {
-    super(key, undefined, padding, heap, asm);
+  constructor(key, heap, asm) {
+    super(key, undefined, false, heap, asm);
 
     this.mode = 'ECB';
     this.BLOCK_SIZE = 16;
@@ -29,12 +28,11 @@ export class AES_ECB extends AES {
 export class AES_ECB_Encrypt extends AES_ECB {
   /**
    * @param {Uint8Array} key
-   * @param {boolean} [padding=true]
    * @param {Uint8Array} [heap]
    * @param {Uint8Array} [asm]
    */
-  constructor(key, padding, heap, asm) {
-    super(key, padding, heap, asm);
+  constructor(key, heap, asm) {
+    super(key, heap, asm);
   }
 
   /**
@@ -65,12 +63,11 @@ export class AES_ECB_Encrypt extends AES_ECB {
 export class AES_ECB_Decrypt extends AES_ECB {
   /**
    * @param {Uint8Array} key
-   * @param {boolean} [padding=true]
    * @param {Uint8Array} [heap]
    * @param {Uint8Array} [asm]
    */
-  constructor(key, padding, heap, asm) {
-    super(key, padding, heap, asm);
+  constructor(key, heap, asm) {
+    super(key, heap, asm);
   }
 
   /**

--- a/src/aes/ecb/exports.js
+++ b/src/aes/ecb/exports.js
@@ -5,16 +5,16 @@
 import {_AES_asm_instance, _AES_heap_instance} from '../exports';
 import {AES_ECB, AES_ECB_Decrypt, AES_ECB_Encrypt} from './ecb';
 
-function AES_ECB_encrypt_bytes ( data, key, padding ) {
+function AES_ECB_encrypt_bytes ( data, key ) {
     if ( data === undefined ) throw new SyntaxError("data required");
     if ( key === undefined ) throw new SyntaxError("key required");
-    return new AES_ECB( key, padding, _AES_heap_instance, _AES_asm_instance).encrypt(data).result;
+    return new AES_ECB( key, _AES_heap_instance, _AES_asm_instance).encrypt(data).result;
 }
 
-function AES_ECB_decrypt_bytes ( data, key, padding ) {
+function AES_ECB_decrypt_bytes ( data, key ) {
     if ( data === undefined ) throw new SyntaxError("data required");
     if ( key === undefined ) throw new SyntaxError("key required");
-    return new AES_ECB( key, padding, _AES_heap_instance, _AES_asm_instance ).decrypt(data).result;
+    return new AES_ECB( key, _AES_heap_instance, _AES_asm_instance ).decrypt(data).result;
 }
 
 

--- a/test/aes.js
+++ b/test/aes.js
@@ -270,13 +270,13 @@ if ( typeof asmCrypto.AES_ECB !== 'undefined' )
                 cipher = new Uint8Array( asmCrypto.hex_to_bytes(ecb_aes_vectors[i][2]) );
 
             equal(
-                asmCrypto.bytes_to_hex( asmCrypto.AES_ECB.encrypt( clear, key, false ) ),
+                asmCrypto.bytes_to_hex( asmCrypto.AES_ECB.encrypt( clear, key ) ),
                 asmCrypto.bytes_to_hex(cipher),
                     "encrypt vector " + i
             );
 
             equal(
-                asmCrypto.bytes_to_hex( asmCrypto.AES_ECB.decrypt( cipher, key, false ) ),
+                asmCrypto.bytes_to_hex( asmCrypto.AES_ECB.decrypt( cipher, key ) ),
                 asmCrypto.bytes_to_hex(clear),
                     "decrypt vector " + i
             );


### PR DESCRIPTION
No padding, no not stretched messages. Only derived messages or randoms at the exact block size.