### PR TITLE
Fix check to only run aes_init once

### DIFF
--- a/src/aes/aes.asm.js
+++ b/src/aes/aes.asm.js
@@ -131,6 +131,8 @@ export var AES_asm = function () {
         aes_dec[t][s] = (aes_dec[t - 1][s] >>> 8) | (aes_dec[t - 1][s] << 24);
       }
     }
+
+    aes_init_done = true;
   }
 
   /**


### PR DESCRIPTION
`aes_init` was taking up the grunt of the time in a toy benchmark of encrypting multiple small messages, so this should result in a decent performance improvement.